### PR TITLE
Allow rotation on compressed file size

### DIFF
--- a/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
+++ b/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
@@ -19,6 +19,8 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
         withRecordFormat(new WARCRecordFormat()).withRotationPolicy(rotpol);
         // dummy sync policy
         withSyncPolicy(new CountSyncPolicy(1000));
+        // trigger rotation on size of compressed WARC file (not uncompressed content)
+        this.setRotationCompressedSizeOffset(true);
         // default local filesystem
         withFsUrl("file:///");
     }


### PR DESCRIPTION
… and make this the default for WARCHdfsBolt.

Needs a review, esp. synchronization: what happens if one thread triggers a rotation while the other is writing?
