### PR TITLE
Fix for #10 WARC-Filename and #12 WARC-Date

### DIFF
--- a/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
+++ b/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
@@ -1,16 +1,21 @@
 package com.digitalpebble.stormcrawler.warc;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.storm.hdfs.bolt.rotation.FileSizeRotationPolicy;
 import org.apache.storm.hdfs.bolt.rotation.FileSizeRotationPolicy.Units;
 import org.apache.storm.hdfs.bolt.sync.CountSyncPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("serial")
 public class WARCHdfsBolt extends GzipHdfsBolt {
+
+    private static final Logger LOG = LoggerFactory
+            .getLogger(WARCHdfsBolt.class);
 
     private byte[] header;
     private Map<String, String> warcInfoFields;
@@ -63,6 +68,7 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
 
     protected Path createOutputFile() throws IOException {
         Path path = super.createOutputFile();
+        LOG.info("Starting new WARC file: {}", path);
 
         // write the header at the beginning of the file
         if (header != null && header.length > 0) {
@@ -71,7 +77,7 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
 
         // write warcinfo record with current date and filename
         if (warcInfoFields != null) {
-            Map<String, String> headerFields = new HashMap<>();
+            Map<String, String> headerFields = new LinkedHashMap<>();
             for (String field : warcInfoOptHeader.keySet()) {
                 String value = warcInfoOptHeader.get(field);
                 if ("WARC-Filename".equals(field) && value == null) {

--- a/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
+++ b/src/main/java/com/digitalpebble/stormcrawler/warc/WARCHdfsBolt.java
@@ -75,9 +75,7 @@ public class WARCHdfsBolt extends GzipHdfsBolt {
             for (String field : warcInfoOptHeader.keySet()) {
                 String value = warcInfoOptHeader.get(field);
                 if ("WARC-Filename".equals(field) && value == null) {
-                    value = path.toString();
-                    value = value.substring(
-                            value.lastIndexOf(Path.SEPARATOR_CHAR) + 1);
+                    value = path.getName();
                 }
                 headerFields.put(field, value);
             }


### PR DESCRIPTION
Depending on what is passed to `WARCHdfsBolt.setWarcInfo(...)` the WARC filename header field is optionally filled (fixes #10):
- only if a key `WARC-Filename` is contained in optionalHeaderFields, the filename is added to the warcinfo record
  - if the corresponding value is null: the actual filename
  - otherwise: the string passed as value is taken

`WARC-Date` is always the current date when the warcinfo record is created, this fixes #12.

The method `WARCHdfsBolt.withHeader(byte[])` is kept but deprecated.

Tested and verified on a 2000 documents test crawl.
